### PR TITLE
Add walking directions and better maps support

### DIFF
--- a/src/BookingsModal.tsx
+++ b/src/BookingsModal.tsx
@@ -154,6 +154,25 @@ const BookingsModal = (props: Props) => {
                                         )}
                                         km away)
                                     </p>
+                                    <p>
+                                        <a
+                                            href={`https://maps.apple.com/?daddr=${locationSlotsPair.location.displayAddress.replace(
+                                                /\s+/g,
+                                                "+"
+                                            )}&dirflg=d&t=r`}
+                                            target="_blank"
+                                            rel="noopener noreferrer"
+                                        >Driving directions</a>
+                                        {" - "}
+                                        <a
+                                            href={`https://maps.apple.com/?daddr=${locationSlotsPair.location.displayAddress.replace(
+                                                /\s+/g,
+                                                "+"
+                                            )}&dirflg=w&t=r`}
+                                            target="_blank"
+                                            rel="noopener noreferrer"
+                                        >Walking directions</a>
+                                    </p>
                                     <a
                                         href="https://bookmyvaccine.nz"
                                         target="_blank"


### PR DESCRIPTION
If accepted, this pull request will add links for walking and driving directions to the vaccine location.

This uses the [Apple Map Links URL scheme](https://developer.apple.com/library/archive/featuredarticles/iPhoneURLScheme_Reference/MapLinks/MapLinks.html)

- On Android, the link will open the Google Maps App (if installed), or Apple Maps web version
- On iOS, the link will open Apple Maps App
- On Windows, the link will open the Windows Maps App (if installed), or Apple Maps web version