### PR TITLE
Fix/go back reverts to default location

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,9 +4,10 @@ import "./App.css";
 import { BookingSection } from "./booking/BookingSection";
 import {
   LocationPicker,
-  useDefaultCoords,
 } from "./location-picker/LocationPicker";
 import { enqueueAnalyticsEvent } from './utils/analytics';
+import { useSearchParams } from "./utils/url";
+import { DEFAULT_LOCATION } from "./utils/location";
 
 import LanguageSelect from "./LanguageSelect";
 
@@ -14,9 +15,14 @@ import { ShareButtons } from "./ShareButtons";
 import { WalkInSection } from "./walk-in/WalkInSection";
 
 function App() {
-  const { lat, lng } = useDefaultCoords();
-  const [coords, setCoords] = useState({ lat, lng });
-  useEffect(() => setCoords({ lat, lng }), [lat, lng]);
+  const {lat, lng} = useSearchParams();
+  const [coords, setCoords] = useState({ lat: DEFAULT_LOCATION.lat, lng: DEFAULT_LOCATION.lng });
+  useEffect(() => {
+      setCoords({ 
+        lat: lat ? parseFloat(lat) : DEFAULT_LOCATION.lat, 
+        lng: lng ? parseFloat(lng) : DEFAULT_LOCATION.lng 
+      })
+  }, [lat, lng]);
 
   const [radiusKm, setRadiusKm] = useState(10);
   const [lastUpdateTime, setLastUpdateTime] = useState<Date | null>(null); // null whilst loading

--- a/src/location-picker/LocationPicker.tsx
+++ b/src/location-picker/LocationPicker.tsx
@@ -54,7 +54,7 @@ export const LocationPicker: FunctionComponent<LocationPickerProps> = ({
               t={t}
               components={[
                 <strong>
-                  {{ location: placeName || "Unknown Location" }}
+                  {{ location: placeName || DEFAULT_LOCATION.placeName }}
                 </strong>,
               ]}
             />

--- a/src/location-picker/LocationPicker.tsx
+++ b/src/location-picker/LocationPicker.tsx
@@ -7,6 +7,7 @@ import RadiusSelect from "../RadiusSelect";
 import { useSearchParams } from "../utils/url";
 import { HeaderMain } from "../VaxComponents";
 import LocationModal from "./LocationModal";
+import { DEFAULT_LOCATION } from "../utils/location";
 
 export interface Coords {
   lng: number;
@@ -21,22 +22,6 @@ interface LocationPickerProps {
   lastUpdateTime: Date | null;
 }
 
-export const useDefaultCoords = (): Coords => {
-  const { lat: urlLat, lng: urlLng } = useSearchParams();
-  const defaultLat = urlLat ? parseFloat(urlLat) : -36.853610199274385;
-  const defaultLng = urlLng ? parseFloat(urlLng) : 174.76054541484535;
-
-  return {
-    lat: defaultLat,
-    lng: defaultLng,
-  };
-};
-
-const useDefaultPlaceName = () => {
-  const { placeName: urlPlaceName } = useSearchParams();
-  return urlPlaceName ?? "Auckland CBD";
-};
-
 export const LocationPicker: FunctionComponent<LocationPickerProps> = ({
   coords,
   setCoords,
@@ -44,10 +29,9 @@ export const LocationPicker: FunctionComponent<LocationPickerProps> = ({
   setRadiusKm,
   lastUpdateTime,
 }) => {
-  const defaultCoords = useDefaultCoords();
-  const defaultPlaceName = useDefaultPlaceName();
-  const [placeName, setPlaceName] = useState(defaultPlaceName);
-  useEffect(() => setPlaceName(defaultPlaceName), [defaultPlaceName]);
+  const { placeName: urlPlaceName } = useSearchParams();
+  const [placeName, setPlaceName] = useState(urlPlaceName);
+  useEffect(() => setPlaceName(urlPlaceName), [urlPlaceName]);
 
   const [isOpen, setIsOpen] = useState(false);
 
@@ -100,8 +84,8 @@ export const LocationPicker: FunctionComponent<LocationPickerProps> = ({
               },
             }}
           >
-            {coords.lat === defaultCoords.lat &&
-            coords.lng === defaultCoords.lng
+            {coords.lat === DEFAULT_LOCATION.lat &&
+            coords.lng === DEFAULT_LOCATION.lng
               ? t("navigation.setLocation")
               : t("navigation.setLocationConfirmation")}
           </Button>

--- a/src/utils/location.ts
+++ b/src/utils/location.ts
@@ -11,3 +11,9 @@ export function getSuburbIsh(
   const short_name = suburbish?.short_name;
   return short_name;
 }
+
+export const DEFAULT_LOCATION = {
+  lat: -36.853610199274385,
+  lng: 174.76054541484535,
+  placeName: "Auckland CBD"
+}

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { DEFAULT_LOCATION } from "./location";
 
 export function useSearchParams() {
   function getSearchParams() {
@@ -11,6 +12,16 @@ export function useSearchParams() {
   const [searchParams, setSearchParams] = useState(getSearchParams());
   useEffect(() => {
     function onHistoryUpdate() {
+      const { lat, lng, placeName } = getSearchParams();
+      if (lat === null || lng === null || placeName === null) {
+        setSearchParams(
+          {
+            lat: DEFAULT_LOCATION.lat.toString(),
+            lng: DEFAULT_LOCATION.lng.toString(),
+            placeName: DEFAULT_LOCATION.placeName
+          }
+        )
+      }
       setSearchParams(getSearchParams());
     }
     window.addEventListener("popstate", onHistoryUpdate);


### PR DESCRIPTION
Hey Team!

This is the fix for the bug in #39 

For some strange reason, the current `useDefaultCoords` & `useDefaultPlaceName` wasn't working as intended, so I have simplified the logic a bit. Open to your thoughts!

I have also added `DEFAULT_LOCATION` to `utils` so can be updated, depending on what we want our initial location to be when the site gets loaded.

