### PR TITLE
fix: remove warning for h3 an p tag nesting

### DIFF
--- a/src/booking/BookingsModal.tsx
+++ b/src/booking/BookingsModal.tsx
@@ -104,11 +104,11 @@ const BookingsModal: FunctionComponent<BookingsModalProps> = ({
                 })
                 : ""}
             </h1>
-            <p>
+            <div>
               {" "}
               <br />
               <h3>{t("calendar.modal.howToBook.title")}</h3>
-            </p>
+            </div>
             <ol className="HelpList">
               <li>{t("calendar.modal.howToBook.stepOne")}</li>
               <li>


### PR DESCRIPTION
As per https://www.w3.org/TR/html401/struct/text.html#h-9.3.1 we cannot have a h3 tag nested within a p tag as p tags only allows inline elements.

This PR switches the p tag to a div to remove the react warning messages.

Addresses #61 