### PR TITLE
Fix localised calendar string in BookingCalendar and BookingsModal

### DIFF
--- a/src/LanguageSelect.tsx
+++ b/src/LanguageSelect.tsx
@@ -6,7 +6,7 @@ import { enqueueAnalyticsEvent } from "./utils/analytics";
 
 
 const LanguageSelect = () => {
-  const langCode = localStorage.getItem("i18nextLng") || "en";
+  const langCode = localStorage.getItem("i18nextLng") || "en-NZ";
   const [language, setLanguage] = useState<Language | undefined>(
     languages.find((lang) => lang.code === langCode),
   );

--- a/src/booking/BookingCalendar.tsx
+++ b/src/booking/BookingCalendar.tsx
@@ -100,16 +100,22 @@ export const BookingCalendar: FunctionComponent<BookingCalendarProps> = ({
               >
                 <div>
                   <h3>
-                    {
-                      new Date(dateLocationsPair.dateStr).toLocaleDateString([i18next.language], {
-                      day: "numeric",
-                      month: "short",
+                    {parse(
+                        dateLocationsPair.dateStr,
+                        "yyyy-MM-dd",
+                        new Date()
+                      ).toLocaleDateString([i18next.language], {
+                        day: "numeric",
+                        month: "short",
                     })}
                     <br />{" "}
                     <aside aria-hidden="true">
-                      {
-                        new Date(dateLocationsPair.dateStr).toLocaleDateString([i18next.language], {
-                        weekday: "short",
+                      {parse(
+                          dateLocationsPair.dateStr,
+                          "yyyy-MM-dd",
+                          new Date()
+                        ).toLocaleDateString([i18next.language], {
+                          weekday: "short",
                       })}
                     </aside>
                   </h3>

--- a/src/booking/BookingCalendar.tsx
+++ b/src/booking/BookingCalendar.tsx
@@ -55,8 +55,8 @@ export const BookingCalendar: FunctionComponent<BookingCalendarProps> = ({
             <h2>
               {
                 parse(
-                  "1 " + month,
-                  "d MMMM yyyy",
+                  month,
+                  "MMMM yyyy",
                   new Date()
                 ).toLocaleDateString([i18next.language], {
                   month: "long",

--- a/src/booking/BookingCalendar.tsx
+++ b/src/booking/BookingCalendar.tsx
@@ -11,6 +11,7 @@ import { DateLocationsPair } from "./BookingDataTypes";
 import { differenceInDays, parse } from "date-fns";
 import { enqueueAnalyticsEvent } from '../utils/analytics';
 import { useTranslation } from "react-i18next";
+import i18next from "i18next";
 
 interface BookingCalendarProps {
   data: BookingData;
@@ -51,7 +52,18 @@ export const BookingCalendar: FunctionComponent<BookingCalendarProps> = ({
       {Array.from(data.entries()).map(([month, dateLocationsPairsForMonth]) => (
         <CalendarSectionContainer key={month}>
           <div className="MonthSection">
-            <h2>{t("calendar.month", { monthString: month })}</h2>
+            <h2>
+              {
+                parse(
+                  "1 " + month,
+                  "d MMMM yyyy",
+                  new Date()
+                ).toLocaleDateString([i18next.language], {
+                  month: "long",
+                  year: "numeric"
+                })
+              }
+            </h2>
           </div>
           <MonthContainer>
             {dateLocationsPairsForMonth.map((dateLocationsPair) => (
@@ -75,7 +87,7 @@ export const BookingCalendar: FunctionComponent<BookingCalendarProps> = ({
                       "yyyy-MM-dd",
                       new Date()
                     ), new Date()),
-                    radiusKm, 
+                    radiusKm,
                     spotsAvailable: sum(
                       dateLocationsPair.locationSlotsPairs.map(
                         (locationSlotsPair) =>
@@ -88,27 +100,15 @@ export const BookingCalendar: FunctionComponent<BookingCalendarProps> = ({
               >
                 <div>
                   <h3>
-                    {parse(
-                      dateLocationsPair.dateStr,
-                      "yyyy-MM-dd",
-                      new Date()
-                    ).toLocaleDateString([], {
+                    {
+                      new Date(dateLocationsPair.dateStr).toLocaleDateString([i18next.language], {
                       day: "numeric",
-                    })}{" "}
-                    {parse(
-                      dateLocationsPair.dateStr,
-                      "yyyy-MM-dd",
-                      new Date()
-                    ).toLocaleDateString([], {
                       month: "short",
                     })}
                     <br />{" "}
                     <aside aria-hidden="true">
-                      {parse(
-                        dateLocationsPair.dateStr,
-                        "yyyy-MM-dd",
-                        new Date()
-                      ).toLocaleDateString([], {
+                      {
+                        new Date(dateLocationsPair.dateStr).toLocaleDateString([i18next.language], {
                         weekday: "short",
                       })}
                     </aside>

--- a/src/booking/BookingsModal.tsx
+++ b/src/booking/BookingsModal.tsx
@@ -15,6 +15,7 @@ import { enqueueAnalyticsEvent } from '../utils/analytics';
 import { differenceInDays } from 'date-fns/esm';
 
 import { useMediaQuery } from "react-responsive";
+import i18next from "i18next";
 type BookingsModalProps = {
   activeDate: DateLocationsPair | null;
   setActiveDate: (activeDate: DateLocationsPair | null) => void;
@@ -83,24 +84,18 @@ const BookingsModal: FunctionComponent<BookingsModalProps> = ({
           <div className="ModalHeader">
             <h1>
               {activeDate
-                ? parse(
-                  activeDate.dateStr,
-                  "yyyy-MM-dd",
-                  new Date()
-                ).toLocaleDateString([], {
-                  weekday: "long",
-                })
+                ?
+                  new Date(activeDate.dateStr).toLocaleDateString([i18next.language], {
+                    weekday: "long"
+                  })
                 : ""}
               <br />
               {activeDate
-                ? parse(
-                  activeDate.dateStr,
-                  "yyyy-MM-dd",
-                  new Date()
-                ).toLocaleDateString([], {
-                  month: "short",
+                ?
+                new Date(activeDate.dateStr).toLocaleDateString([i18next.language], {
                   day: "numeric",
-                  year: "numeric",
+                  month: "short",
+                  year: "numeric"
                 })
                 : ""}
             </h1>

--- a/src/booking/BookingsModal.tsx
+++ b/src/booking/BookingsModal.tsx
@@ -84,15 +84,21 @@ const BookingsModal: FunctionComponent<BookingsModalProps> = ({
           <div className="ModalHeader">
             <h1>
               {activeDate
-                ?
-                  new Date(activeDate.dateStr).toLocaleDateString([i18next.language], {
+                ? parse(
+                  activeDate.dateStr,
+                  "yyyy-MM-dd",
+                  new Date()
+                ).toLocaleDateString([i18next.language], {
                     weekday: "long"
-                  })
+                })
                 : ""}
               <br />
               {activeDate
-                ?
-                new Date(activeDate.dateStr).toLocaleDateString([i18next.language], {
+                ? parse(
+                  activeDate.dateStr,
+                  "yyyy-MM-dd",
+                  new Date()
+                ).toLocaleDateString([i18next.language], {
                   day: "numeric",
                   month: "short",
                   year: "numeric"

--- a/src/translations/index.ts
+++ b/src/translations/index.ts
@@ -1,7 +1,7 @@
 import { resources } from "./resources";
 import languages from "./resources";
 
-let initLanguage = localStorage.getItem("i18nextLng") || "en";
+let initLanguage = localStorage.getItem("i18nextLng") || "en-NZ";
 
 const options = {
   order: ["querystring", "navigator"],
@@ -10,11 +10,11 @@ const options = {
 
 export const config = {
   lng: initLanguage,
-  fallbackLng: "en",
+  fallbackLng: "en-NZ",
   ns: ["common"],
   defaultNS: "common",
   detection: options,
-  supportedLngs: ["en", "es", "de", "ru", "zh", "zh-CN", "zh-TW"],
+  supportedLngs: ["en-NZ", "es", "de", "ru", "zh", "zh-CN", "zh-TW"],
   interpolation: { escapeValue: false },
   resources,
   debug: true,

--- a/src/translations/resources.ts
+++ b/src/translations/resources.ts
@@ -16,7 +16,7 @@ const languages: Language[] = [
   {
     common: common_en,
     label: "English",
-    code: "en",
+    code: "en-NZ",
   },
   {
     common: common_es,

--- a/src/utils/locale.ts
+++ b/src/utils/locale.ts
@@ -8,5 +8,5 @@ import i18next from "i18next";
  */
 export const getDateFnsLocale = (): Locale => {
   const lang = i18next.language;
-  return Locales[lang.substring(0, 2) as keyof typeof Locales] ?? Locales.enNZ;
+  return Locales[lang.replace('-', '') as keyof typeof Locales] ?? Locales.enNZ;
 };


### PR DESCRIPTION
This PR fixes some issues in date localisation so that the month on the top of the calendar ("September 2021"), the date in the calendar ("21 Sep") and in the calendar modal can be localised following different regions convention.