### PR TITLE
Use local lint-staged binary

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,4 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-lint-staged
+yarn lint-staged


### PR DESCRIPTION
We should use the locally pulled `lint-staged` binary to ensure all developers use the same version. We also can't be sure that a developer has `lint-staged` installed globally especially since our current requirements are Node and Yarn, so that would prevent them from committing their changes as the pre-commit hook would fail.

Related to #77