### PR TITLE
WIP: Real time MoH booking slots

### DIFF
--- a/src/booking/BookingLocation.tsx
+++ b/src/booking/BookingLocation.tsx
@@ -1,0 +1,175 @@
+/* eslint-disable react/jsx-no-target-blank */
+import { Button } from "baseui/button";
+import { VaccineCentre } from "../VaxComponents";
+import {
+  DateLocationsPair,
+  LocationSlotsPair,
+  SlotWithAvailability,
+} from "./BookingDataTypes";
+import { getDistanceKm } from "../utils/distance";
+import { parse } from "date-fns";
+import { Coords } from "../location-picker/LocationPicker";
+import { FunctionComponent, useEffect, useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
+
+import { enqueueAnalyticsEvent } from "../utils/analytics";
+import { differenceInDays } from "date-fns/esm";
+
+import { useSeen } from "../utils/useSeen";
+
+type BookingLocationProps = {
+  locationSlotsPair: LocationSlotsPair;
+  coords: Coords;
+  activeDate: DateLocationsPair;
+  radiusKm: number;
+};
+
+const BookingLocation: FunctionComponent<BookingLocationProps> = ({
+  locationSlotsPair,
+  coords,
+  radiusKm,
+  activeDate,
+}) => {
+  const { t } = useTranslation("common");
+  const ref = useRef() as any;
+  const seen = useSeen(ref, "20px");
+  const [slots, setSlots] = useState<SlotWithAvailability[] | undefined>();
+
+  const getSlots = async (url: string) => {
+    const res = await fetch(url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        vaccineData: "WyJhMVQ0YTAwMDAwMEhJS0NFQTQiXQ==",
+        groupSize: 1,
+        url: "https://app.bookmyvaccine.covid19.health.nz/appointment-select",
+        timeZone: "Pacific/Auckland",
+      }),
+    });
+    const dataStr = await res.text();
+    let data;
+    try {
+      data = JSON.parse(dataStr);
+    } catch (e) {
+      console.log("Couldn't parse JSON. Response text below");
+      console.log("res.status", res.status);
+      console.log(dataStr);
+      throw e;
+    }
+    return data;
+  };
+
+  useEffect(() => {
+    async function load() {
+      if (!seen || slots) {
+        return;
+      }
+      const response = await getSlots(
+        `https://moh2.weston.sh/public/locations/${locationSlotsPair.location.extId}/date/${activeDate.dateStr}/slots`
+      );
+      setSlots(response.slotsWithAvailability);
+    }
+    load();
+  }, [seen, slots, setSlots, locationSlotsPair.location.extId, activeDate.dateStr]);
+
+  const slotsToDisplay =
+    slots && slots.length > 0 ? slots : locationSlotsPair.slots;
+  return (
+    <VaccineCentre ref={ref}>
+      <h3>{locationSlotsPair.location.name}</h3>
+      <p>
+        {locationSlotsPair.location.displayAddress} (
+        {t("core.kmAway", {
+          distance: Math.floor(
+            getDistanceKm(coords, locationSlotsPair.location.location)
+          ),
+        })}
+        )
+      </p>
+      <p>
+        <a
+          href={`https://www.google.com/maps/dir/?api=1&destination=${locationSlotsPair.location.location.lat},${locationSlotsPair.location.location.lng}`}
+          target="_blank"
+          rel="noopener noreferrer"
+          onClick={() =>
+            enqueueAnalyticsEvent("Get Directions clicked", {
+              radiusKm,
+              spotsAvailable: locationSlotsPair.slots?.length || 0,
+              bookingDateInDays: differenceInDays(
+                parse(activeDate.dateStr, "yyyy-MM-dd", new Date()),
+                new Date()
+              ),
+            })
+          }
+        >
+          {t("core.getDirections")}
+        </a>
+      </p>
+      <a
+        href="https://bookmyvaccine.covid19.health.nz"
+        target="_blank"
+        referrerPolicy="origin"
+        rel="noreferrer"
+      >
+        <div className="ButtonConstraint">
+          <Button
+            overrides={{
+              Root: {
+                style: {
+                  width: "100%",
+                  marginTop: "1rem",
+                  marginRight: 0,
+                  marginBottom: "1rem",
+                  marginLeft: 0,
+                },
+              },
+            }}
+            onClick={() =>
+              enqueueAnalyticsEvent("Make a Booking clicked", {
+                locationName: locationSlotsPair.location.name,
+                radiusKm,
+                spotsAvailable: slotsToDisplay?.length || 0,
+                bookingDateInDays: differenceInDays(
+                  parse(activeDate.dateStr, "yyyy-MM-dd", new Date()),
+                  new Date()
+                ),
+              })
+            }
+          >
+            {t("core.makeABooking")}
+          </Button>
+        </div>
+      </a>
+      <p
+        style={{
+          marginTop: "0.25rem",
+          marginRight: 0,
+          marginBottom: "0.5rem",
+          marginLeft: 0,
+        }}
+      >
+        {t("calendar.modal.availableSlots")}
+      </p>
+      <section>
+        {/* <p>1am</p> */}
+        {slotsToDisplay?.map((slot) => (
+          <p key={slot.localStartTime}>
+            {parse(
+              slot.localStartTime,
+              "HH:mm:ss",
+              new Date()
+            ).toLocaleTimeString("en-NZ", {
+              hour: "2-digit",
+              minute: "2-digit",
+              hour12: true,
+            })}
+          </p>
+        ))}
+      </section>
+    </VaccineCentre>
+  );
+};
+
+export default BookingLocation;

--- a/src/booking/BookingsModal.tsx
+++ b/src/booking/BookingsModal.tsx
@@ -1,8 +1,11 @@
 /* eslint-disable react/jsx-no-target-blank */
 import { Modal } from "baseui/modal";
 import { Button, KIND } from "baseui/button";
-import { ModalGrid, VaccineCentre } from "../VaxComponents";
-import { DateLocationsPair, LocationSlotsPair } from "./BookingDataTypes";
+import { ModalGrid } from "../VaxComponents";
+import {
+  DateLocationsPair,
+  LocationSlotsPair,
+} from "./BookingDataTypes";
 import { getDistanceKm } from "../utils/distance";
 import { parse } from "date-fns";
 import { sortByAsc } from "../utils/array";
@@ -11,10 +14,11 @@ import { Coords } from "../location-picker/LocationPicker";
 import { FunctionComponent } from "react";
 import { useTranslation, Trans } from "react-i18next";
 
-import { enqueueAnalyticsEvent } from '../utils/analytics';
-import { differenceInDays } from 'date-fns/esm';
+import { enqueueAnalyticsEvent } from "../utils/analytics";
 
 import { useMediaQuery } from "react-responsive";
+import BookingLocation from "./BookingLocation";
+
 type BookingsModalProps = {
   activeDate: DateLocationsPair | null;
   setActiveDate: (activeDate: DateLocationsPair | null) => void;
@@ -84,24 +88,24 @@ const BookingsModal: FunctionComponent<BookingsModalProps> = ({
             <h1>
               {activeDate
                 ? parse(
-                  activeDate.dateStr,
-                  "yyyy-MM-dd",
-                  new Date()
-                ).toLocaleDateString([], {
-                  weekday: "long",
-                })
+                    activeDate.dateStr,
+                    "yyyy-MM-dd",
+                    new Date()
+                  ).toLocaleDateString([], {
+                    weekday: "long",
+                  })
                 : ""}
               <br />
               {activeDate
                 ? parse(
-                  activeDate.dateStr,
-                  "yyyy-MM-dd",
-                  new Date()
-                ).toLocaleDateString([], {
-                  month: "short",
-                  day: "numeric",
-                  year: "numeric",
-                })
+                    activeDate.dateStr,
+                    "yyyy-MM-dd",
+                    new Date()
+                  ).toLocaleDateString([], {
+                    month: "short",
+                    day: "numeric",
+                    year: "numeric",
+                  })
                 : ""}
             </h1>
             <div>
@@ -132,7 +136,7 @@ const BookingsModal: FunctionComponent<BookingsModalProps> = ({
 
             <Button
               onClick={() => {
-                enqueueAnalyticsEvent('Back to Calendar clicked');
+                enqueueAnalyticsEvent("Back to Calendar clicked");
                 setActiveDate(null);
               }}
               overrides={{
@@ -165,100 +169,13 @@ const BookingsModal: FunctionComponent<BookingsModalProps> = ({
             sortByDistance(activeDate?.locationSlotsPairs, coords)
               .filter((locationSlotsPair) => locationSlotsPair.slots?.length)
               .map((locationSlotsPair) => (
-                <VaccineCentre key={locationSlotsPair.location.extId}>
-                  <h3>{locationSlotsPair.location.name}</h3>
-                  <p>
-                    {locationSlotsPair.location.displayAddress} (
-                    {t("core.kmAway", {
-                      distance: Math.floor(
-                        getDistanceKm(
-                          coords,
-                          locationSlotsPair.location.location
-                        )
-                      ),
-                    })}
-                    )
-                  </p>
-                  <p>
-                    <a
-                      href={`https://www.google.com/maps/dir/?api=1&destination=${locationSlotsPair.location.location.lat},${locationSlotsPair.location.location.lng}`}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      onClick={() => enqueueAnalyticsEvent('Get Directions clicked', {
-                        radiusKm,
-                        spotsAvailable: locationSlotsPair.slots?.length || 0,
-                        bookingDateInDays: differenceInDays(parse(
-                          activeDate.dateStr,
-                          "yyyy-MM-dd",
-                          new Date()
-                        ), new Date()),
-                      })}
-                    >
-                      {t("core.getDirections")}
-                    </a>
-                  </p>
-                  <a
-                    href="https://bookmyvaccine.covid19.health.nz"
-                    target="_blank"
-                    referrerPolicy="origin"
-                    rel="noreferrer"
-                  >
-                    <div className="ButtonConstraint">
-                      <Button
-                        overrides={{
-                          Root: {
-                            style: {
-                              width: "100%",
-                              marginTop: "1rem",
-                              marginRight: 0,
-                              marginBottom: "1rem",
-                              marginLeft: 0,
-                            },
-                          },
-                        }}
-                        onClick={() =>
-                          enqueueAnalyticsEvent('Make a Booking clicked', {
-                            locationName: locationSlotsPair.location.name,
-                            radiusKm,
-                            spotsAvailable: locationSlotsPair.slots?.length || 0,
-                            bookingDateInDays: differenceInDays(parse(
-                              activeDate.dateStr,
-                              "yyyy-MM-dd",
-                              new Date()
-                            ), new Date()),
-                          })}
-                      >
-                        {t("core.makeABooking")}
-                      </Button>
-                    </div>
-                  </a>
-                  <p
-                    style={{
-                      marginTop: "0.25rem",
-                      marginRight: 0,
-                      marginBottom: "0.5rem",
-                      marginLeft: 0,
-                    }}
-                  >
-                    {t("calendar.modal.availableSlots")}
-                  </p>
-                  <section>
-                    {/* <p>1am</p> */}
-                    {locationSlotsPair.slots?.map((slot) => (
-                      <p key={slot.localStartTime}>
-                        {parse(
-                          slot.localStartTime,
-                          "HH:mm:ss",
-                          new Date()
-                        ).toLocaleTimeString("en-NZ", {
-                          hour: "2-digit",
-                          minute: "2-digit",
-                          hour12: true,
-                        })}
-                      </p>
-                    ))}
-                  </section>
-                </VaccineCentre>
+                <BookingLocation
+                  key={locationSlotsPair.location.extId}
+                  locationSlotsPair={locationSlotsPair}
+                  coords={coords}
+                  radiusKm={radiusKm}
+                  activeDate={activeDate}
+                />
               ))
           ) : (
             <>
@@ -288,8 +205,8 @@ const BookingsModal: FunctionComponent<BookingsModalProps> = ({
       <div className="MobileOnly">
         <Button
           onClick={() => {
-            setActiveDate(null)
-            enqueueAnalyticsEvent('Back to Calendar clicked');
+            setActiveDate(null);
+            enqueueAnalyticsEvent("Back to Calendar clicked");
           }}
           overrides={{
             Root: {
@@ -311,3 +228,4 @@ const BookingsModal: FunctionComponent<BookingsModalProps> = ({
   );
 };
 export default BookingsModal;
+

--- a/src/utils/useSeen.ts
+++ b/src/utils/useSeen.ts
@@ -1,0 +1,27 @@
+import React, { useState, useEffect } from "react";
+
+export const useSeen = (ref: React.RefObject<HTMLElement>, within: string) => {
+  const [isIntersecting, setIntersecting] = useState(false);
+  useEffect(() => {
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          setIntersecting(true);
+        }
+      },
+      {
+        rootMargin: `0px 0px ${within} 0px`,
+      }
+    );
+    if (ref.current) {
+      observer.observe(ref.current);
+    }
+    const current = ref.current;
+    return () => {
+      if (current) {
+        observer.unobserve(current);
+      }
+    };
+  }, [ref, within]);
+  return isIntersecting;
+};


### PR DESCRIPTION
This PR add's real time slot availability to the calendar when you open a location modal.

How we are doing this is proxying requests to get real time slots from the MoH booking system. There is some non public infrastructure components that are making this happen which are not complete yet so take this PR as a proof of concept (similar infrastructure to how we are running our scraper).

How this PR works is we by default load our cached data which is publicly available at our data github repo, then in the background fire off requests to the real booking system to update the data in real time for the user. If the requests fail for any reason we keep displaying the non updated data.

