### PR TITLE
Fix/update set location logic

### DIFF
--- a/src/location-picker/LocationModal.tsx
+++ b/src/location-picker/LocationModal.tsx
@@ -29,6 +29,18 @@ const LocationModal = (props: Props) => {
     setLocationIsOpen(false);
   }, [setLocationIsOpen]);
 
+  const getMetaDataLocation = (metaData: MetaData) => {
+    const { city, region, suburb } = metaData;
+
+    if (suburb == null && city == null) {
+      return region;
+    } else if (suburb == null) {
+      return city;
+    } else {
+      return suburb;
+    }
+  };
+
   const setLocation = useCallback(
     (lat: number, lng: number, name?: string | null) => {
       const placeName = name ?? `${lat} ${lng}`;
@@ -64,10 +76,12 @@ const LocationModal = (props: Props) => {
         );
 
         widget.on("result:select", function (fullAddress, metaData) {
+          const locationName = getMetaDataLocation(metaData);
+
           setLocation(
             parseFloat(metaData.y),
             parseFloat(metaData.x),
-            metaData.suburb
+            locationName
           );
         });
       }


### PR DESCRIPTION
This fixes #111 

Previously we would setLocation params based on suburb. Now the logic includes city & region.

p.s. notice below that when `Wellington Region` is set, it doesn't show any data @oeed @noway 

<img width="1509" alt="Screen Shot 2021-09-11 at 12 37 45 AM" src="https://user-images.githubusercontent.com/58315812/132854356-3383bd1a-f971-4d53-b7cc-732904b2b8b1.png">
<img width="1572" alt="Screen Shot 2021-09-11 at 12 37 24 AM" src="https://user-images.githubusercontent.com/58315812/132854362-3745bb02-7df0-4caf-83b9-6946a4bad8b4.png">
<img width="1580" alt="Screen Shot 2021-09-11 at 12 42 06 AM" src="https://user-images.githubusercontent.com/58315812/132854852-42dc81e2-e565-49f5-8760-89e8b91c3a56.png">
