### PR TITLE
sets language selecter placeholder to English

### DIFF
--- a/src/LanguageSelect.tsx
+++ b/src/LanguageSelect.tsx
@@ -41,7 +41,7 @@ const LanguageSelect = () => {
       options={languages}
       valueKey="code"
       value={language ? [language] : undefined}
-      placeholder="Language"
+      placeholder="English"
       onChange={(params) => {
         changeLanguage(params.option);
       }}


### PR DESCRIPTION
Sets `placeholder` of `Select` to `"English"` in `LanguageSelect.tsx` so language select drop down will display English by default per issue #123.

Let me know if it needs any tweaking!