### PR TITLE
Shareable links for languages

### DIFF
--- a/src/LanguageSelect.tsx
+++ b/src/LanguageSelect.tsx
@@ -15,6 +15,9 @@ const LanguageSelect = () => {
     let newLang = languages.find((lang) => lang.code === selectedLanguage.code);
     setLanguage(newLang);
     i18n.changeLanguage(newLang?.code);
+    const url = new URL(window.location.toString());
+    url.searchParams.set("locale", String(newLang?.code.toLocaleLowerCase()));
+    window.history.pushState({}, "", url.toString());
     enqueueAnalyticsEvent("Language changed", { code: newLang?.code });
   };
 

--- a/src/translations/index.ts
+++ b/src/translations/index.ts
@@ -3,7 +3,7 @@ import languages from "./resources";
 
 const options = {
   order: ["querystring", "localStorage", "navigator"],
-  lookupQuerystring: "lang",
+  lookupQuerystring: "locale",
 };
 
 export const config = {

--- a/src/translations/index.ts
+++ b/src/translations/index.ts
@@ -1,15 +1,12 @@
 import { resources } from "./resources";
 import languages from "./resources";
 
-let initLanguage = localStorage.getItem("i18nextLng") || "en-NZ";
-
 const options = {
-  order: ["querystring", "navigator"],
+  order: ["querystring", "localStorage", "navigator"],
   lookupQuerystring: "lang",
 };
 
 export const config = {
-  lng: initLanguage,
   fallbackLng: "en-NZ",
   ns: ["common"],
   defaultNS: "common",

--- a/src/translations/resources.ts
+++ b/src/translations/resources.ts
@@ -9,7 +9,6 @@ import common_sm_SM from "./locales/common_sm-SM.json";
 import common_to_TO from "./locales/common_to-TO.json";
 import common_vi_VN from "./locales/common_vi-VN.json";
 
-
 export type Language = {
   common: Object; //typeof common_en_NZ;
   label: string;


### PR DESCRIPTION
Added the `?locale=[code]` into the query string to make it shareable while maintaining the originally selected language (closes #98).

I have also reordered the language detector to prioritise language selection in this order: `["querystring", "localStorage", "navigator"]` and tidied up the code.