### PR TITLE
Removed lodash

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "@testing-library/user-event": "^12.1.10",
     "@types/google.maps": "^3.45.6",
     "@types/jest": "^26.0.15",
-    "@types/lodash": "^4.14.172",
     "@types/node": "^12.0.0",
     "@types/react": "^17.0.0",
     "@types/react-dom": "^17.0.0",
@@ -40,7 +39,6 @@
     "fs": "^0.0.1-security",
     "husky": "^7.0.0",
     "lint-staged": "^11.1.2",
-    "lodash": "^4.17.21",
     "prettier": "^2.3.2",
     "ts-node": "^10.2.1",
     "typescript": "^4.1.2"

--- a/src/translations/scripts/syncTranslations.ts
+++ b/src/translations/scripts/syncTranslations.ts
@@ -1,10 +1,30 @@
-import english from "../locales/common_en-NZ.json";
 import fs from "fs";
 import { join } from "path";
+import english from "../locales/common_en-NZ.json";
 import { traverseTranslations } from "./traverseTranslations";
-import { get, set } from "lodash";
 
 const paths = traverseTranslations();
+
+const set = (string: string, obj: any, value: string) => {
+  const [current, ...rest] = string.split(".");
+  rest.length >= 1
+    ? set(rest.join("."), (obj[current] = obj[current] || {}), value)
+    : (obj[current] = value);
+  return obj;
+};
+
+const get = (value: object, path: string, defaultValue: string) => {
+  return String(path)
+    .split(".")
+    .reduce((acc: any, v: any) => {
+      try {
+        acc = acc[v];
+      } catch (e) {
+        return defaultValue;
+      }
+      return acc;
+    }, value);
+};
 
 export interface IHash {
   [locale: string]: number;
@@ -28,8 +48,8 @@ fs.readdirSync(join(__dirname, "../locales")).forEach((locale) => {
   }
 
   paths.forEach((p) => {
-    if (get(data, p, null) === null) {
-      set(data, p, get(english, p));
+    if (get(data, p, "") === undefined) {
+      set(p, data, get(english, p, ""));
       missingKeys[locale] = missingKeys[locale] ? missingKeys[locale] + 1 : 1;
     }
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2012,11 +2012,6 @@
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
   integrity sha1-7ihweulOEdK4J7y+UnC86n8+ce4=
 
-"@types/lodash@^4.14.172":
-  version "4.14.172"
-  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.172.tgz#aad774c28e7bfd7a67de25408e03ee5a8c3d028a"
-  integrity sha512-/BHF5HAx3em7/KkzVKm3LrsD6HZAXuXO1AJZQ3cRRBZj4oHZDviWPYu0aEplAqDFNHZPW6d3G7KN+ONcCCC7pw==
-
 "@types/minimatch@*":
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.3.tgz#3dca0e3f33b200fc7d1139c0cd96c1268cadfd9d"
@@ -7610,7 +7605,7 @@ lodash.uniq@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
 
-"lodash@>=3.5 <5", lodash@^4.17.11, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.17.5:
+"lodash@>=3.5 <5", lodash@^4.17.11, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.5:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==


### PR DESCRIPTION
This PR removes the `lodash` dev dependency. Previously required `lodash` functions have been re-written in JS in the hope that this reduces the bundle size as per #151 