### PR TITLE
[Bundle size] Fix issue with bundle size too big

### DIFF
--- a/src/utils/locale.ts
+++ b/src/utils/locale.ts
@@ -1,6 +1,17 @@
-import * as Locales from "date-fns/locale";
+import { enNZ, de, es, ru, vi, zhCN, zhTW, mn } from "date-fns/locale"; // Only import locale we support. Don't use import * it is bad
 import { Locale } from "date-fns";
 import i18next from "i18next";
+
+const supportedDateLocale: { [localeString: string]: Locale } = {
+  enNZ,
+  de,
+  "ms-My": mn, // Same issue
+  es,
+  ru,
+  viVN: vi, // Don't ask me i18 locale string is different than date-fns locale string so ¯\_(ツ)_/¯
+  zhTW,
+  zhCN,
+};
 
 /**
  * Looks up a date-fns locale. This falls back to `en-NZ`
@@ -8,5 +19,10 @@ import i18next from "i18next";
  */
 export const getDateFnsLocale = (): Locale => {
   const lang = i18next.language;
-  return Locales[lang.replace("-", "") as keyof typeof Locales] ?? Locales.enNZ;
+  const splittedLocale = lang.split("-");
+  const localeString =
+    splittedLocale[0].toLowerCase() === splittedLocale[1].toLowerCase()
+      ? splittedLocale[0]
+      : splittedLocale.join("");
+  return supportedDateLocale[localeString] ?? enNZ;
 };


### PR DESCRIPTION
Only import locale object that we support to avoid gigantic bundle size from `date-fns`. Some how this fix issue with time string display for different locale too 🤷 

![](https://media0.giphy.com/media/3oEjI53nBYOOEQgDcY/giphy.gif)

Before 

<img width="1419" alt="Screen Shot 2021-09-12 at 8 57 21 AM" src="https://user-images.githubusercontent.com/29682322/132962363-dfa67faa-690a-4ebd-a347-c1a0e5d4e8b3.png">

After:

<img width="1421" alt="Screen Shot 2021-09-12 at 9 44 14 AM" src="https://user-images.githubusercontent.com/29682322/132962367-2230751a-3253-46df-9f20-7efd9af70978.png">
