### PR TITLE
Format translations with Prettier on i18n sync (trailing new line)

### DIFF
--- a/src/translations/scripts/syncTranslations.ts
+++ b/src/translations/scripts/syncTranslations.ts
@@ -1,5 +1,6 @@
 import fs from "fs";
 import { join } from "path";
+import prettier from "prettier";
 import english from "../locales/common_en-NZ.json";
 import { traverseTranslations } from "./traverseTranslations";
 
@@ -54,7 +55,12 @@ fs.readdirSync(join(__dirname, "../locales")).forEach((locale) => {
     }
   });
 
-  fs.writeFileSync(filename, JSON.stringify(data, null, 2));
+  fs.writeFileSync(
+    filename,
+    prettier.format(JSON.stringify(data), {
+      parser: "json",
+    })
+  );
 });
 
 console.log("NEW TRANSLATIONS REQUIRED:");


### PR DESCRIPTION
This PR adds the ability to auto format the translation files with `prettier` when they sync.

Prior to this, a new line was not added to the end of the JSON files, causing CI to fail. Writing the data using `prettier` formatting ensures the new line is automatically added.
