### PR TITLE
[Date locale] Fix wrong key value mapping between i18 and date-fns locale

### DIFF
--- a/src/utils/locale.ts
+++ b/src/utils/locale.ts
@@ -3,14 +3,14 @@ import { Locale } from "date-fns";
 import i18next from "i18next";
 
 const supportedDateLocale: { [localeString: string]: Locale } = {
-  enNZ,
-  de,
-  "ms-My": mn, // Same issue
-  es,
-  ru,
-  viVN: vi, // Don't ask me i18 locale string is different than date-fns locale string so ¯\_(ツ)_/¯
-  zhTW,
-  zhCN,
+  "en-NZ": enNZ,
+  "de-DE": de,
+  "ms-MY": mn, // Same issue
+  "es-ES": es,
+  "ru-RU": ru,
+  "vi-VN": vi, // Don't ask me i18 locale string is different than date-fns locale string so ¯\_(ツ)_/¯
+  "zh-TW": zhTW,
+  "zh-CN": zhCN,
 };
 
 /**
@@ -19,10 +19,5 @@ const supportedDateLocale: { [localeString: string]: Locale } = {
  */
 export const getDateFnsLocale = (): Locale => {
   const lang = i18next.language;
-  const splittedLocale = lang.split("-");
-  const localeString =
-    splittedLocale[0].toLowerCase() === splittedLocale[1].toLowerCase()
-      ? splittedLocale[0]
-      : splittedLocale.join("");
-  return supportedDateLocale[localeString] ?? enNZ;
+  return supportedDateLocale[lang] ?? enNZ;
 };


### PR DESCRIPTION
![](https://media3.giphy.com/media/VhoLNmkoO92zleTLQH/giphy.gif)

I also tried to trim down bundle size further but unsure  how to trim that fat `Select` component from base.UI

<img width="1421" alt="Screen Shot 2021-09-12 at 4 47 37 PM" src="https://user-images.githubusercontent.com/29682322/132972649-1830e80e-a764-4199-8880-cd2c1e1ae26a.png">
