### PR TITLE
Put crowdsource location merge closer to `BookingData` generation

### DIFF
--- a/src/calendar/CalendarData.ts
+++ b/src/calendar/CalendarData.ts
@@ -32,38 +32,38 @@ export const useCalendarLocations = (
   radiusKm: number,
   setLastUpdateTime: (time: Date | null) => void
 ) => {
-  const crowdSourced = getCrowdsourcedLocations(coords, radiusKm);
+  // const crowdSourced = getCrowdsourcedLocations(coords, radiusKm);
   const bookingData = useBookingData(coords, radiusKm, setLastUpdateTime);
   if ("ok" in bookingData) {
     const months: CalendarData = bookingData.ok;
 
-    const MAX_DAYS = 60;
-    const today = new Date();
-    for (const location of crowdSourced) {
-      for (let i = 0; i < MAX_DAYS; i++) {
-        // add crowd sourced locations to each calendar day they're open
-        const date = addDays(today, i);
-        const isOpen = location.openingHours.find(
-          (a) => a.day === date.getDay()
-        )?.isOpen;
-        if (!isOpen) {
-          continue;
-        }
+    // const MAX_DAYS = 60;
+    // const today = new Date();
+    // for (const location of crowdSourced) {
+    //   for (let i = 0; i < MAX_DAYS; i++) {
+    //     // add crowd sourced locations to each calendar day they're open
+    //     const date = addDays(today, i);
+    //     const isOpen = location.openingHours.find(
+    //       (a) => a.day === date.getDay()
+    //     )?.isOpen;
+    //     if (!isOpen) {
+    //       continue;
+    //     }
 
-        const dateStr = format(date, "yyyy-MM-dd");
-        const monthStr = date.toLocaleString("en-NZ", {
-          month: "long",
-          year: "numeric",
-        });
-        const month: CalendarMonth = months.get(monthStr) ?? new Map();
+    //     const dateStr = format(date, "yyyy-MM-dd");
+    //     const monthStr = date.toLocaleString("en-NZ", {
+    //       month: "long",
+    //       year: "numeric",
+    //     });
+    //     const month: CalendarMonth = months.get(monthStr) ?? new Map();
 
-        const day: CalendarDateLocations = month.get(dateStr) ?? [];
+    //     const day: CalendarDateLocations = month.get(dateStr) ?? [];
 
-        day.push(location);
-        month.set(dateStr, day);
-        months.set(monthStr, month);
-      }
-    }
+    //     day.push(location);
+    //     month.set(dateStr, day);
+    //     months.set(monthStr, month);
+    //   }
+    // }
 
     return {
       ok: new Map(

--- a/src/calendar/CalendarData.ts
+++ b/src/calendar/CalendarData.ts
@@ -1,8 +1,4 @@
-import { addDays, format } from "date-fns";
-import {
-  CrowdsourcedLocation,
-  getCrowdsourcedLocations,
-} from "../crowdsourced/CrowdsourcedData";
+import { CrowdsourcedLocation } from "../crowdsourced/CrowdsourcedData";
 import { Coords } from "../location-picker/LocationPicker";
 import { useBookingData } from "./booking/BookingData";
 import { BookingLocationSlotsPair } from "./booking/BookingDataTypes";
@@ -32,39 +28,9 @@ export const useCalendarLocations = (
   radiusKm: number,
   setLastUpdateTime: (time: Date | null) => void
 ) => {
-  // const crowdSourced = getCrowdsourcedLocations(coords, radiusKm);
   const bookingData = useBookingData(coords, radiusKm, setLastUpdateTime);
   if ("ok" in bookingData) {
     const months: CalendarData = bookingData.ok;
-
-    // const MAX_DAYS = 60;
-    // const today = new Date();
-    // for (const location of crowdSourced) {
-    //   for (let i = 0; i < MAX_DAYS; i++) {
-    //     // add crowd sourced locations to each calendar day they're open
-    //     const date = addDays(today, i);
-    //     const isOpen = location.openingHours.find(
-    //       (a) => a.day === date.getDay()
-    //     )?.isOpen;
-    //     if (!isOpen) {
-    //       continue;
-    //     }
-
-    //     const dateStr = format(date, "yyyy-MM-dd");
-    //     const monthStr = date.toLocaleString("en-NZ", {
-    //       month: "long",
-    //       year: "numeric",
-    //     });
-    //     const month: CalendarMonth = months.get(monthStr) ?? new Map();
-
-    //     const day: CalendarDateLocations = month.get(dateStr) ?? [];
-
-    //     day.push(location);
-    //     month.set(dateStr, day);
-    //     months.set(monthStr, month);
-    //   }
-    // }
-
     return {
       ok: new Map(
         Array.from(months).sort((a, b) => String(b[0]).localeCompare(a[0]))

--- a/src/calendar/booking/BookingData.ts
+++ b/src/calendar/booking/BookingData.ts
@@ -1,10 +1,17 @@
-import { format, parse } from "date-fns";
+import { addDays, format, parse } from "date-fns";
 import i18next from "i18next";
 import { useCallback, useEffect, useMemo, useState } from "react";
+import { getCrowdsourcedLocations } from "../../crowdsourced/CrowdsourcedData";
 import filterOldDates from "../../filterOldDates";
 import { Coords } from "../../location-picker/LocationPicker";
 import { getDistanceKm } from "../../utils/distance";
-import { DateString, MonthString } from "../CalendarData";
+import {
+  CalendarData,
+  CalendarDateLocations,
+  CalendarMonth,
+  DateString,
+  MonthString,
+} from "../CalendarData";
 import {
   BookingDateLocations,
   BookingLocationSlotsPair,
@@ -104,7 +111,11 @@ export type BookingData = Map<
   Map<DateString, BookingLocationSlotsPair[]>
 >;
 
-function getBookingData(bookingDateLocations: BookingDateLocations[]) {
+function getBookingData(
+  bookingDateLocations: BookingDateLocations[],
+  coords: Coords,
+  radiusKm: number
+) {
   const dateLocationsPairs = filterOldDates(bookingDateLocations);
   let byMonth: BookingData = new Map();
   dateLocationsPairs.forEach((dateLocationsPair) => {
@@ -120,6 +131,37 @@ function getBookingData(bookingDateLocations: BookingDateLocations[]) {
     );
     byMonth.set(month, mapToPush);
   });
+  const crowdSourced = getCrowdsourcedLocations(coords, radiusKm);
+
+  const months: CalendarData = byMonth;
+  const MAX_DAYS = 60;
+  const today = new Date();
+  for (const location of crowdSourced) {
+    for (let i = 0; i < MAX_DAYS; i++) {
+      // add crowd sourced locations to each calendar day they're open
+      const date = addDays(today, i);
+      const isOpen = location.openingHours.find(
+        (a) => a.day === date.getDay()
+      )?.isOpen;
+      if (!isOpen) {
+        continue;
+      }
+
+      const dateStr = format(date, "yyyy-MM-dd");
+      const monthStr = date.toLocaleString("en-NZ", {
+        month: "long",
+        year: "numeric",
+      });
+      const month: CalendarMonth = months.get(monthStr) ?? new Map();
+
+      const day: CalendarDateLocations = month.get(dateStr) ?? [];
+
+      day.push(location);
+      month.set(dateStr, day);
+      months.set(monthStr, month);
+    }
+  }
+
   return byMonth;
 }
 
@@ -152,11 +194,10 @@ export const useBookingData = (
   }, [coords, radiusKm, setDateLocationsPairs, setLastUpdateTime]);
 
   // FOR FUTURE: set directly in setState to reduce RAM usage?
-  // const byMonth = useMemo(
-  //   () => getBookingData(dateLocationsPairs),
-  //   [dateLocationsPairs]
-  // );
-  const byMonth = getBookingData(dateLocationsPairs);
+  const byMonth = useMemo(
+    () => getBookingData(dateLocationsPairs, coords, radiusKm),
+    [coords, dateLocationsPairs, radiusKm]
+  );
 
   useEffect(() => {
     loadCalendar();

--- a/src/calendar/booking/BookingData.ts
+++ b/src/calendar/booking/BookingData.ts
@@ -16,7 +16,7 @@ import {
   BookingDateLocations,
   BookingLocationSlotsPair,
   Location,
-  LocationsData,
+  AvailabilityData,
 } from "./BookingDataTypes";
 
 const NZbbox = [166.509144322, -46.641235447, 178.517093541, -34.4506617165];
@@ -29,11 +29,11 @@ async function getLocations() {
   return data;
 }
 
-async function getLocationData(extId: string) {
+async function getAvailabilityData(extId: string) {
   const res = await fetch(
     `https://raw.githubusercontent.com/CovidEngine/vaxxnzlocations/main/availability/${extId}.json`
   );
-  const data: LocationsData = await res.json();
+  const data: AvailabilityData = await res.json();
   return data;
 }
 
@@ -59,9 +59,9 @@ async function getMyCalendar(coords: Coords, radiusKm: number) {
   let oldestLastUpdatedTimestamp = Infinity;
   const availabilityDatesAndLocations = await Promise.all(
     filtredLocations.map(async (location) => {
-      let locationsData: LocationsData | undefined = undefined;
+      let locationsData: AvailabilityData | undefined = undefined;
       try {
-        locationsData = await getLocationData(location.extId);
+        locationsData = await getAvailabilityData(location.extId);
       } catch (e) {
         console.error("getMyCalendar e", e);
       }
@@ -111,7 +111,7 @@ export type BookingData = Map<
   Map<DateString, BookingLocationSlotsPair[]>
 >;
 
-function getBookingData(
+function generateBookingData(
   bookingDateLocations: BookingDateLocations[],
   coords: Coords,
   radiusKm: number
@@ -195,7 +195,7 @@ export const useBookingData = (
 
   // FOR FUTURE: set directly in setState to reduce RAM usage?
   const byMonth = useMemo(
-    () => getBookingData(dateLocationsPairs, coords, radiusKm),
+    () => generateBookingData(dateLocationsPairs, coords, radiusKm),
     [coords, dateLocationsPairs, radiusKm]
   );
 

--- a/src/calendar/booking/BookingDataTypes.ts
+++ b/src/calendar/booking/BookingDataTypes.ts
@@ -36,7 +36,7 @@ export interface AvailabilityDates {
   [key: string]: SlotWithAvailability[] | undefined;
 }
 
-export interface LocationsData {
+export interface AvailabilityData {
   availabilityDates: AvailabilityDates;
   lastUpdatedAt: string;
 }


### PR DESCRIPTION
We had an issue: when memoizing `byMonth: BookingData`, crowdsourced location would start duplicating in the date modal. I had to disable memoizing due to this issue. That affects performance.

This was happening because Oli did `day.push(location);` in a mutating fashion to a memoized array - it would fill up over multiple renders. 

The solution is to put `day.push(location);` code BEFORE memoize happens. That is, into `getBookingData`.

This PR puts `day.push(location);` code into `getBookingData` and enables back memoizing.

@oeed please review this code. Can you poke holes in it? Btw, your code worked perfectly before I introduced `useMemo`, so it was my bad for not testing it properly.

Cheers.