### PR TITLE
Prevent package-lock.json being committed

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,7 +22,8 @@ jobs:
           cache: 'yarn'
 
       - name: Ensure package-lock.json does not exist
-        run: ! test -f package-lock.json || echo "Please remove package-lock.json and re-run dependency installation with yarn. We use yarn v1 for package management."
+        run: |
+          ! test -f package-lock.json || echo "Please remove package-lock.json and re-run dependency installation with yarn. We use yarn v1 for package management."
       - name: Install dependencies
         run: yarn install --frozen-lockfile || echo "Drifiting has occurred between package.json and yarn.lock. Run `yarn install` to update the lock file."
       - name: Run prettier

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,4 +29,4 @@ jobs:
       - name: Run prettier
         run: yarn prettier --check src || echo "Please make sure your code is prettified by running `yarn prettier --write src` before committing."
       - name: Run tests
-        run: CI=true yarn test
+        run: CI=true yarn test --coverage

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,9 +21,11 @@ jobs:
           node-version: '14'
           cache: 'yarn'
 
+      - name: Ensure package-lock.json does not exist
+        run: ! test -f package-lock.json || echo "Please remove package-lock.json and re-run dependency installation with yarn. We use yarn v1 for package management."
       - name: Install dependencies
-        run: yarn install --frozen-lockfile
+        run: yarn install --frozen-lockfile || echo "Drifiting has occurred between package.json and yarn.lock. Run `yarn install` to update the lock file."
       - name: Run prettier
-        run: yarn prettier --check src
+        run: yarn prettier --check src || echo "Please make sure your code is prettified by running `yarn prettier --write src` before committing."
       - name: Run tests
         run: CI=true yarn test

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
 
 # dependencies
+package-lock.json
 /node_modules
 /.pnp
 .pnp.js


### PR DESCRIPTION
This PR adds package-lock.json to our .gitignore file. An additional check is also added into our presubmit jobs to be safe.