### PR TITLE
Fix: format slot times according to locale

### DIFF
--- a/src/calendar/BookingLocation.tsx
+++ b/src/calendar/BookingLocation.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable react/jsx-no-target-blank */
 import { Button } from "baseui/button";
+import i18next from "i18next";
 import { isToday, isAfter } from "date-fns";
 import { VaccineCentre } from "../VaxComponents";
 import { formatDistanceKm, getDistanceKm } from "../utils/distance";
@@ -9,6 +10,7 @@ import { FunctionComponent, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import { enqueueAnalyticsEvent } from "../utils/analytics";
+import { formatToLocaleTimeString } from "../utils/date";
 import { differenceInDays } from "date-fns/esm";
 
 import { useSeen } from "../utils/useSeen";
@@ -190,15 +192,7 @@ const BookingLocation: FunctionComponent<BookingLocationProps> = ({
         {/* <p>1am</p> */}
         {slotsToDisplay?.map((slot) => (
           <p key={slot.localStartTime}>
-            {parse(
-              slot.localStartTime,
-              "HH:mm:ss",
-              new Date()
-            ).toLocaleTimeString("en-NZ", {
-              hour: "2-digit",
-              minute: "2-digit",
-              hour12: true,
-            })}
+            {formatToLocaleTimeString(slot.localStartTime, i18n.language)}
           </p>
         ))}
       </section>

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -1,0 +1,20 @@
+import { parse } from "date-fns";
+
+/**
+ * Formats a time string (in HH:mm:ss) to locale specific format
+ *
+ * @export
+ * @param {string} timeString
+ * @param {string} language
+ * @returns  {string} The formated string in locale specific format
+ */
+export function formatToLocaleTimeString(
+  timeString: string,
+  language: string
+): string {
+  return new Intl.DateTimeFormat(language, {
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: true,
+  }).format(parse(timeString, "HH:mm:ss", new Date()));
+}

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -13,7 +13,7 @@ export function formatToLocaleTimeString(
   timeString: string,
   language: string
 ): string {
-  return format(parse(timeString, "HH:mm:ss", new Date()), "HH:mm aa", {
+  return format(parse(timeString, "HH:mm:ss", new Date()), "hh:mm aa", {
     locale: getDateFnsLocale(),
   });
 }

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -1,5 +1,6 @@
-import { parse } from "date-fns";
+import { parse, format } from "date-fns";
 
+import { getDateFnsLocale } from "./locale";
 /**
  * Formats a time string (in HH:mm:ss) to locale specific format
  *
@@ -12,9 +13,19 @@ export function formatToLocaleTimeString(
   timeString: string,
   language: string
 ): string {
-  return new Intl.DateTimeFormat(language, {
-    hour: "2-digit",
-    minute: "2-digit",
-    hour12: true,
-  }).format(parse(timeString, "HH:mm:ss", new Date()));
+  return format(parse(timeString, "HH:mm:ss", new Date()), "HH:mm aa", {
+    locale: getDateFnsLocale(),
+  });
 }
+/*
+ *export function formatToLocaleTimeString(
+ *  timeString: string,
+ *  language: string
+ *): string {
+ *  return new Intl.DateTimeFormat(language, {
+ *    hour: "2-digit",
+ *    minute: "2-digit",
+ *    hour12: true,
+ *  }).format(parse(timeString, "HH:mm:ss", new Date()));
+ *}
+ */


### PR DESCRIPTION
## Proposed Changes
1. Added a function to parse and format slot time based on language

## Additional Info.
Closes #187 
