### PR TITLE
add vaxx.nz twitter handle

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -156,7 +156,16 @@ function App() {
               {t("footer.links.sourceCode")}
             </a>{" "}
           </p>
-          <p></p>
+          <p>
+            <a
+              href="https://twitter.com/vaxxnz"
+              target="_blank"
+              rel="noreferrer"
+              onClick={() => enqueueAnalyticsEvent("Twitter Clicked")}
+            >
+              Twitter
+            </a>{" "}
+          </p>
         </footer>
       </div>
       <div className="background">


### PR DESCRIPTION
## Proposed Changes
1. adds vaxx.nz twitter handle to footer

## Screenshots (optional)
![Screen Shot 2021-09-16 at 12 07 51 AM](https://user-images.githubusercontent.com/9004833/133430533-4fd8ba57-79e2-4cb3-8d99-4709e93b41c7.png)