### PR TITLE
Fix issue with modal display empty modal for a split second

### DIFF
--- a/src/calendar/modal/CalendarModal.tsx
+++ b/src/calendar/modal/CalendarModal.tsx
@@ -51,6 +51,7 @@ const BookingModal: FunctionComponent<BookingModalProps> = ({
 
   return (
     <Modal
+      animate={false}
       onClose={close}
       isOpen={!!activeDate}
       unstable_ModalBackdropScroll={true}


### PR DESCRIPTION
## Proposed Changes
1. Avoid using animation. Because there's a css animation delaying closing modal for a few seconds. Another fix I can think of is using `setTimeout` but it seems ugly. This solution will make UX a little bit less nice I guess 🤷 

![](https://media1.giphy.com/media/ZBEnmms00tJt6ZlFtF/giphy.gif)

Address https://github.com/CovidEngine/vaxxnz/issues/145

## Additional Info.

This is the animation applied to the modal

<img width="321" alt="Screen Shot 2021-09-16 at 9 32 54 PM" src="https://user-images.githubusercontent.com/29682322/133588308-e85df587-25cf-4cee-9fd4-f4c4cc414c4c.png">

After the fix, the modals seems snappier so there's a cons about not using animation.

https://user-images.githubusercontent.com/29682322/133588424-74247213-e607-4111-81df-90640c55cff6.mov
