### PR TITLE
Fix a broken link for CONTRIBUTING_DEV

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,4 +27,4 @@ Here are some ways to help:
 
 ## For Developers:
 
-- Have a look at our technical guide on [how to get started](CONTRIBUTORS_DEV.md)
+- Have a look at our technical guide on [how to get started](CONTRIBUTING_DEV.md)


### PR DESCRIPTION
## Proposed Changes
1. This is simply to fix the link to CONTRIBUTING_DEV which wasn't updated after renaming the file.

## Screenshots (optional)
