### PR TITLE
Improve Polish translation

### DIFF
--- a/src/calendar/BookingLocation.tsx
+++ b/src/calendar/BookingLocation.tsx
@@ -196,7 +196,7 @@ const BookingLocation = ({
                 })
               }
             >
-              Change or cancel a Booking
+              {t("core.changeOrCancelABooking")}
             </Button>
           </a>
         </div>

--- a/src/translations/locales/common_ar-IQ.json
+++ b/src/translations/locales/common_ar-IQ.json
@@ -17,7 +17,8 @@
     "walkInDriveThru": "Walk-in/Drive Thru",
     "availableBookingSlots": "Available Booking Slots",
     "vaccApptToBook": "Vaccination appointments available to book right now.",
-    "mistake": "Did we make a mistake?"
+    "mistake": "Did we make a mistake?",
+    "changeOrCancelABooking": "Change or cancel a Booking"
   },
   "navigation": {
     "about": "معلومات",

--- a/src/translations/locales/common_de-DE.json
+++ b/src/translations/locales/common_de-DE.json
@@ -17,7 +17,8 @@
     "walkInDriveThru": "Walk-in/Drive Thru",
     "availableBookingSlots": "Available Booking Slots",
     "vaccApptToBook": "Vaccination appointments available to book right now.",
-    "mistake": "Did we make a mistake?"
+    "mistake": "Did we make a mistake?",
+    "changeOrCancelABooking": "Change or cancel a Booking"
   },
   "navigation": {
     "about": "Über uns",

--- a/src/translations/locales/common_en-NZ.json
+++ b/src/translations/locales/common_en-NZ.json
@@ -7,7 +7,8 @@
     "loading": "Loading...",
     "getDirections": "Get Directions",
     "makeABooking": "Make a Booking",
-    "walkInDriveThru":"Walk-in/Drive Thru",
+    "changeOrCancelABooking": "Change or cancel a Booking",
+    "walkInDriveThru": "Walk-in/Drive Thru",
     "distanceAway": "{{distance}} away",
     "lastUpdated": "Last updated {{updatedAt}}",
     "cancel": "Cancel",
@@ -17,7 +18,7 @@
     "noResultsInRadius": "No vaccination sites found for this search query. Try a different search radius.",
     "availableBookingSlots": "Available Booking Slots",
     "vaccApptToBook": "Vaccination appointments available to book right now.",
-    "mistake" : "Did we make a mistake?"
+    "mistake": "Did we make a mistake?"
   },
   "navigation": {
     "about": "About",

--- a/src/translations/locales/common_es-ES.json
+++ b/src/translations/locales/common_es-ES.json
@@ -17,7 +17,8 @@
     "walkInDriveThru": "Walk-in/Drive Thru",
     "availableBookingSlots": "Available Booking Slots",
     "vaccApptToBook": "Vaccination appointments available to book right now.",
-    "mistake": "Did we make a mistake?"
+    "mistake": "Did we make a mistake?",
+    "changeOrCancelABooking": "Change or cancel a Booking"
   },
   "navigation": {
     "about": "Sobre nosotros",

--- a/src/translations/locales/common_hi-HI.json
+++ b/src/translations/locales/common_hi-HI.json
@@ -17,7 +17,8 @@
     "walkInDriveThru": "Walk-in/Drive Thru",
     "availableBookingSlots": "Available Booking Slots",
     "vaccApptToBook": "Vaccination appointments available to book right now.",
-    "mistake": "Did we make a mistake?"
+    "mistake": "Did we make a mistake?",
+    "changeOrCancelABooking": "Change or cancel a Booking"
   },
   "navigation": {
     "about": "के बारे में",

--- a/src/translations/locales/common_id-ID.json
+++ b/src/translations/locales/common_id-ID.json
@@ -17,7 +17,8 @@
     "walkInDriveThru": "Walk-in/Drive Thru",
     "availableBookingSlots": "Available Booking Slots",
     "vaccApptToBook": "Vaccination appointments available to book right now.",
-    "mistake": "Did we make a mistake?"
+    "mistake": "Did we make a mistake?",
+    "changeOrCancelABooking": "Change or cancel a Booking"
   },
   "navigation": {
     "about": "Mengenai",

--- a/src/translations/locales/common_ja-JP.json
+++ b/src/translations/locales/common_ja-JP.json
@@ -17,7 +17,8 @@
     "walkInDriveThru": "Walk-in/Drive Thru",
     "availableBookingSlots": "Available Booking Slots",
     "vaccApptToBook": "Vaccination appointments available to book right now.",
-    "mistake": "Did we make a mistake?"
+    "mistake": "Did we make a mistake?",
+    "changeOrCancelABooking": "Change or cancel a Booking"
   },
   "navigation": {
     "about": "このウェブサイトについて",

--- a/src/translations/locales/common_mi-NZ.json
+++ b/src/translations/locales/common_mi-NZ.json
@@ -17,7 +17,8 @@
     "walkInDriveThru": "Walk-in/Drive Thru",
     "availableBookingSlots": "Available Booking Slots",
     "vaccApptToBook": "Vaccination appointments available to book right now.",
-    "mistake": "Did we make a mistake?"
+    "mistake": "Did we make a mistake?",
+    "changeOrCancelABooking": "Change or cancel a Booking"
   },
   "navigation": {
     "about": "Taipitopito",

--- a/src/translations/locales/common_ms-MY.json
+++ b/src/translations/locales/common_ms-MY.json
@@ -17,7 +17,8 @@
     "walkInDriveThru": "Walk-in/Drive Thru",
     "availableBookingSlots": "Available Booking Slots",
     "vaccApptToBook": "Vaccination appointments available to book right now.",
-    "mistake": "Did we make a mistake?"
+    "mistake": "Did we make a mistake?",
+    "changeOrCancelABooking": "Change or cancel a Booking"
   },
   "navigation": {
     "about": "Mengenai",

--- a/src/translations/locales/common_pl-PL.json
+++ b/src/translations/locales/common_pl-PL.json
@@ -97,7 +97,6 @@
       "backToCalendar": "Powrót do kalendarza"
     }
   },
-
   "footer": {
     "message": "Jeżeli ta strona pomogła ci, rozważ udostępnienie jej innym",
     "addressFinderLinkCopy": "Dziękujemy <0>AddressFinder</0> za darmowy dostęp do wyszukiwań adresów",

--- a/src/translations/locales/common_pl-PL.json
+++ b/src/translations/locales/common_pl-PL.json
@@ -1,31 +1,39 @@
 {
   "core": {
     "title": "Vaxx.nz",
-    "tagline": "Znajdź szczepionkę przeciw COVID-19",
+    "tagline": "Znajdź szczepienie przeciw COVID-19",
     "subtitle": "Sprawdź możliwości zaszczepienia się w twojej okolicy.",
-    "disclaimerNotAGovWebsite": "Nie jest to oficjalna strona rządu. Aby zaszczepić się odwiedź stronę <0>bookmyvaccine.nz</0>",
+    "disclaimerNotAGovWebsite": "Nie jest to oficjalna strona rządowa. Aby się zaszczepić odwiedź stronę <0>bookmyvaccine.nz</0>",
     "loading": "Ładowanie...",
     "getDirections": "Jak dojechać",
-    "makeABooking": "Zrób rezerwacje",
+    "makeABooking": "Zrób rezerwację",
+    "changeOrCancelABooking": "Zmień lub anuluj rezerwację",
+    "walkInDriveThru": "Walk-in/Drive Thru",
     "distanceAway": "{{distance}} odległości",
     "lastUpdated": "Dane sprzed {{updatedAt}}",
-    "cancel": "Odwołać",
+    "cancel": "Anuluj",
     "website": "Strona Internetowa",
     "address": "Adres",
-    "noResultsNotInNZ": "No vaccination sites found for this search query. Are you in New Zealand?",
-    "noResultsInRadius": "No vaccination sites found for this search query. Try a different kilometer radius.",
-    "walkInDriveThru": "Walk-in/Drive Thru",
-    "availableBookingSlots": "Available Booking Slots",
-    "vaccApptToBook": "Vaccination appointments available to book right now.",
-    "mistake": "Did we make a mistake?"
+    "noResultsNotInNZ": "Nie znaleziono mijesc szczepień dla twojego zapytania. Czy jesteś w Nowej Zelandii?",
+    "noResultsInRadius": "Nie znaleziono miejsc szczepień dla twojego zapytania. Spróbuj inny promień wyszukiwania.",
+    "availableBookingSlots": "Dostępne terminy na rezerwację",
+    "vaccApptToBook": "Wizyty na szczepienia które są teraz dostępne do zarezerwowania.",
+    "mistake": "Czy popełniliśmy bląd?"
   },
   "navigation": {
     "about": "O Nas",
     "contact": "Kontakt",
     "getInvolved": "Włącz się do akcji",
-    "setLocation": "Wskaż miejsce, w którym się znajdujesz.",
+    "setLocation": "Ustaw swoją lokalizację",
     "setLocationConfirmation": "Lokalizacja ustawiona",
-    "vaccinationsNear": "Dostępne szczepionki <0> w pobliżu {{location}}</0>",
+    "locationModal": {
+      "locaitonTitle": "Lokalizacja",
+      "locationCTA": "Wpisz adres lub okolice",
+      "useCurrentLocation": "Użyj moją obecną lokalizację",
+      "geolocationNotSupported": "Twója przeglądarka nie wspiera geolokalizacji"
+    },
+    "vaccinationsNear": "Dostępne szczepienia <0>w pobliżu {{location}}</0>",
+    "unknownLocation": "Nieznane miejsce",
     "distanceDropdown": {
       "2km": "W zasięgu 2km",
       "5km": "W zasięgu 5km",
@@ -33,78 +41,71 @@
       "25km": "W zasięgu 25km",
       "50km": "W zasięgu 50km",
       "100km": "W zasięgu 100km",
-      "10closest": "10 closest"
-    },
-    "locationModal": {
-      "locaitonTitle": "Lokalizacja",
-      "locationCTA": "Wpisz adres lub okolice",
-      "useCurrentLocation": "Użyj moją obecną lokalizacje",
-      "geolocationNotSupported": "twój browser nie pozwala użycia geolokalizacji"
-    },
-    "unknownLocation": "Nieznane miejsce"
+      "10closest": "10 najbliższych"
+    }
   },
   "walkins": {
-    "sectionHeader": "Centra szczepienia dostępne bez rezerwacji i Drive-through <0>- Otwarte dzisiaj</0>",
-    "openString": "Otwarte {{openTimeString}}",
+    "sectionHeader": "Centra szczepień dostępne bez rezerwacji i Drive-through <0>- Otwarte dzisiaj</0>",
+    "subHeader": "Nie potrzebujesz się umawiać żeby zaszczepić się w tym miejscu. Odwiedź <0>covid19.govt.nz</0> żeby dowiedzieć się więcej.",
+    "noWalkinDriveThruFound": "W Twojej okolicy nie ma żadnych punktów szczepień bez rejestracji ani drive-thru. Spróbuj zamiast tego zrobić rezerwację.",
+    "openString": "Otwarte od {{openTimeString}}",
     "cancellationNotice": {
       "info": "Proszę nie rezerwować się podwójnie",
       "message": "Pamiętaj odwołać ustaloną poprzednią rezerwacje jeżeli masz nową na stronie <0>bookmyvaccine.nz</0>"
     },
-    "cancelBooking": "Odwołać",
+    "cancelBooking": "Anuluj",
     "noticeList": {
-      "title": "Dostępność nie jest zagwarantowana",
-      "text": "Pamiętaj że centra niewymagające rezerwacji mogą nie mieć miejsc."
+      "title": "Jak się Zaszczepić?",
+      "text": "Do szczepień może być kolejka i niektóre miejsca mogą dzisiaj nie mieć wolnych szczepionek - zadzwoń wcześniej jak możesz!"
+    },
+    "healthpointModal": {
+      "title": "Jak się tutaj zaszczepić",
+      "subtitle": "Odwiedź poniższy adres i poproś o bezpłatną szczepionke przeciwko COVID.",
+      "queueQuery": "Możesz również zadzwonić na <0>{{telephone}}</0> żeby sprawdzić jak długie są kolejki.",
+      "venueDetails": "Informacje dotyczące miejsca"
     },
     "walkinAwailable": "<0 /> Dostępne centra bez rezerwacji",
     "driveThroughAvailable": "<0 /> Dostępne Drive-through",
     "phone": "Telefon",
     "hours": "Godziny",
+    "closed": "Zamknięte",
     "publicHolidays": "Święta państwowe",
     "otherExeptions": "Wyjątki",
     "seeMore": "Zobacz więcej",
-    "closed": "Closed",
     "otherLocations": {
-      "sectionHeader": "inne miejsca szczepienia <0>- otwarte dzisiaj</0>",
+      "sectionHeader": "Inne miejsca szczepień <0>- otwarte dzisiaj</0>",
       "disclaimer": {
-        "title": "to miejsce było zgłoszone przez mieszkańców",
-        "message": "Informacja na tej stronie może nie być poprawna w 100%. Sprawdź informacje na stronie danego centrum."
+        "title": "To miejsce było zgłoszone przez mieszkańców",
+        "message": "Podane tutaj informacje mogą nie być w 100% dokładne. Prosimy o zapoznanie się ze stroną tego miejsca."
       }
-    },
-    "subHeader": "You don't need an appointment to get vaccinated at these venues. Visit <0>covid19.govt.nz</0> for more information.",
-    "noWalkinDriveThruFound": "There aren't any walk-in or drive thru vaccination centres in your area. Try make a booking instead.",
-    "healthpointModal": {
-      "title": "How to get vaccinated here",
-      "subtitle": "Visit the address below and ask for a free COVID vaccination.",
-      "queueQuery": "You can also call <0>{{telephone}}</0> to check how long the queues are.",
-      "venueDetails": "Venue Details"
     }
   },
   "calendar": {
     "month": "{{monthString, MMMM yyyy}}",
-    "numberOfDoses": "{{numberOfDoses}} dostępne",
+    "numberOfAppointments": "{{sumAvailableTimes}} dostępnych",
     "modal": {
       "howToBook": {
         "title": "Jak zarezerwować",
-        "stepOne": "Wybierz lokalizację i godzinę z następującej listy",
-        "stepTwo": "Kliknij na guzik <i>Zrób rezerwacje</i> , który cię przeniesie do strony <0>bookmyvaccine.nz</0>",
-        "stepThree": "Wpisz Swoje dane.",
-        "stepFour": "Następnie odpowiedz na pytanie, które miejsce i czas ci odpowiada."
+        "stepOne": "Wybierz miejsce i godzinę z następującej listy",
+        "stepTwo": "Kliknij guzik <i>Zrób rezerwację</i>, który przeniesie ciebie na stronę <0>bookmyvaccine.nz</0>",
+        "stepThree": "Wpisz swoje dane.",
+        "stepFour": "Kiedy zostaniesz poproszony, wyszukaj swoje preferowane miejsce i czas."
       },
       "availableSlots": "Dostępne miejsca",
-      "noBookingsAvailable": "Nie ma dostępnych rezerwacji w tym dniu :(",
-      "backToCalendar": "Powrót do kalendarza",
-      "notBMV": "Ta lokalizacja nie używa <0>bookmyvaccine.nz</0> i może nie mieć wolnych miejsc."
-    },
-    "numberOfAppointments": "{{sumAvailableTimes}} dost"
+      "noBookingsAvailable": "Nie ma żadnych dostępnych rezerwacji w tym dniu :(",
+      "notBMV": "Te miejsce nie używa <0>bookmyvaccine.nz</0> i może nie mieć wolnych miejsc.",
+      "backToCalendar": "Powrót do kalendarza"
+    }
   },
+
   "footer": {
     "message": "Jeżeli ta strona pomogła ci, rozważ udostępnienie jej innym",
+    "addressFinderLinkCopy": "Dziękujemy <0>AddressFinder</0> za darmowy dostęp do wyszukiwań adresów",
     "links": {
       "contactUs": "Zkontaktuj się z Nami",
-      "rawData": "Dane podstawowe",
-      "sourceCode": "Kod źródłowy",
-      "roadmap": "Mapa drogowa"
-    },
-    "addressFinderLinkCopy": "Dziękujemy <0>AddressFinder</0> za darmowy dostęp do wyszukiwań adresów"
+      "rawData": "Surowe Dane",
+      "sourceCode": "Kod Źródłowy",
+      "roadmap": "Plan Rozwoju"
+    }
   }
 }

--- a/src/translations/locales/common_ru-RU.json
+++ b/src/translations/locales/common_ru-RU.json
@@ -17,7 +17,8 @@
     "walkInDriveThru": "Walk-in/Drive Thru",
     "availableBookingSlots": "Available Booking Slots",
     "vaccApptToBook": "Vaccination appointments available to book right now.",
-    "mistake": "Did we make a mistake?"
+    "mistake": "Did we make a mistake?",
+    "changeOrCancelABooking": "Change or cancel a Booking"
   },
   "navigation": {
     "about": "О нас",

--- a/src/translations/locales/common_sm-SM.json
+++ b/src/translations/locales/common_sm-SM.json
@@ -17,7 +17,8 @@
     "walkInDriveThru": "Walk-in/Drive Thru",
     "availableBookingSlots": "Available Booking Slots",
     "vaccApptToBook": "Vaccination appointments available to book right now.",
-    "mistake": "Did we make a mistake?"
+    "mistake": "Did we make a mistake?",
+    "changeOrCancelABooking": "Change or cancel a Booking"
   },
   "navigation": {
     "about": "Uiga Tāua",

--- a/src/translations/locales/common_tl-PH.json
+++ b/src/translations/locales/common_tl-PH.json
@@ -17,7 +17,8 @@
     "walkInDriveThru": "Walk-in/Drive Thru",
     "availableBookingSlots": "Available Booking Slots",
     "vaccApptToBook": "Vaccination appointments available to book right now.",
-    "mistake": "Did we make a mistake?"
+    "mistake": "Did we make a mistake?",
+    "changeOrCancelABooking": "Change or cancel a Booking"
   },
   "navigation": {
     "about": "Tungkol",

--- a/src/translations/locales/common_to-TO.json
+++ b/src/translations/locales/common_to-TO.json
@@ -17,7 +17,8 @@
     "walkInDriveThru": "Walk-in/Drive Thru",
     "availableBookingSlots": "Available Booking Slots",
     "vaccApptToBook": "Vaccination appointments available to book right now.",
-    "mistake": "Did we make a mistake?"
+    "mistake": "Did we make a mistake?",
+    "changeOrCancelABooking": "Change or cancel a Booking"
   },
   "navigation": {
     "about": "Fekau'aki",

--- a/src/translations/locales/common_vi-VN.json
+++ b/src/translations/locales/common_vi-VN.json
@@ -17,7 +17,8 @@
     "walkInDriveThru": "Walk-in/Drive Thru",
     "availableBookingSlots": "Available Booking Slots",
     "vaccApptToBook": "Vaccination appointments available to book right now.",
-    "mistake": "Did we make a mistake?"
+    "mistake": "Did we make a mistake?",
+    "changeOrCancelABooking": "Change or cancel a Booking"
   },
   "navigation": {
     "about": "Về Vaxx.nz",

--- a/src/translations/locales/common_zh-CN.json
+++ b/src/translations/locales/common_zh-CN.json
@@ -17,7 +17,8 @@
     "walkInDriveThru": "Walk-in/Drive Thru",
     "availableBookingSlots": "Available Booking Slots",
     "vaccApptToBook": "Vaccination appointments available to book right now.",
-    "mistake": "Did we make a mistake?"
+    "mistake": "Did we make a mistake?",
+    "changeOrCancelABooking": "Change or cancel a Booking"
   },
   "navigation": {
     "about": "关于",

--- a/src/translations/locales/common_zh-TW.json
+++ b/src/translations/locales/common_zh-TW.json
@@ -17,7 +17,8 @@
     "walkInDriveThru": "Walk-in/Drive Thru",
     "availableBookingSlots": "Available Booking Slots",
     "vaccApptToBook": "Vaccination appointments available to book right now.",
-    "mistake": "Did we make a mistake?"
+    "mistake": "Did we make a mistake?",
+    "changeOrCancelABooking": "Change or cancel a Booking"
   },
   "navigation": {
     "about": "關於",


### PR DESCRIPTION
Kia ora,

_Just to give a rough idea how well I know Polish and English:_
I was born in Poland and Polish is my native language. My CEFR English level is
C1 and I have translated a huge % of Tor's website (over 900 strings, can't
tell the exact numbers).

---

- Some strings were outdated(?)
- Some of the strings sounded like something taken from Google Translate (very literal translation)
	> `"roadmap": "Mapa drogowa"` - makes no sense if you don't know the English word
	> `"rawData": "Dane podstawowe"` - weird (in literal translation - basic data)
	> `"cancel": "Odwołać"` - weird choice if we consider context
- Some were not translated
	> `"10closest": "10 closest"`
	> `"mistake": "Did we make a mistake?"`
	> `"changeOrCancelABooking": "Change or cancel a Booking"`

I also wanted to translate "to", but I don't have any idea how to do that.
![image](https://user-images.githubusercontent.com/38681822/134463289-bce1d8de-a8ed-4cce-8538-259fe4cb647f.png)
All I can tell is that it's part of `openTimeString`.