### PR TITLE
Fix walk-in opening time alignment for Safari

### DIFF
--- a/src/VaxComponents.js
+++ b/src/VaxComponents.js
@@ -373,7 +373,7 @@ export const WalkMessage = styled.div`
 export const WalkBox = styled.button`
   box-sizing: border-box;
   font-family: inherit;
-  min-height: 144px;
+  min-height: 112px;
   height: 100%;
   width: 100%;
   flex: 1;
@@ -412,6 +412,7 @@ export const WalkBox = styled.button`
     flex-direction: column;
     justify-content: space-between;
     height: 100%;
+    min-height: inherit;
   }
   .Chevron {
     width: 1.25rem;


### PR DESCRIPTION
## Proposed Changes
Same fix for walk-in opening time alignment as availability label

Tested on macOS big sur:
Safari 14.1.2
Google Chrome 94
Microsoft Edge 93

