### PR TITLE
Disable auto translate since we're offering human translated versions

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en-nz">
+<html lang="en-nz" translate="no">
   <head>
     <!-- Google Tag Manager -->
     <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
@@ -26,6 +26,7 @@
       name="description"
       content="Find a COVID-19 vaccine. See ways to get vaccinated near you. This is not an official Government website. To get vaccinated visit bookmyvaccine.nz"
     />
+    <meta name="google" content="notranslate">
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link


### PR DESCRIPTION
## Proposed Changes
1. Disable auto translate since we're offering human translated versions

## Additional Info.
Prevents Google Translate popping up in Google Chrome and offering to translate page.
