### PR TITLE
Backlink to vaxx.nz widget

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,4 +47,5 @@ Following our launch, we welcomed an average of 2,800 users every 30 minutes! Al
 
 ## Resources
 
-Periodically updated JSON of all available slots: [see raw data here](https://github.com/CovidEngine/vaxxnzlocations)
+- Periodically updated JSON of all available slots: [see raw data here](https://github.com/CovidEngine/vaxxnzlocations)
+- Vaxx.nz Widget: [see here](https://docs.vaxx.nz)

--- a/src/Footer.tsx
+++ b/src/Footer.tsx
@@ -96,7 +96,7 @@ export function Footer() {
           <a
             href="https://docs.vaxx.nz"
             onClick={() => enqueueAnalyticsEvent("Vaxx.nz Widget Clicked")}
-            title="Vaxx.nz Widget - Vaxx.nz Widget"
+            title="Vaxx.nz Widget"
           >
             Vaxx.nz Widget
           </a>{" "}

--- a/src/Footer.tsx
+++ b/src/Footer.tsx
@@ -92,6 +92,14 @@ export function Footer() {
           >
             Twitter
           </a>{" "}
+          /{" "}
+          <a
+            href="https://docs.vaxx.nz"
+            onClick={() => enqueueAnalyticsEvent("Vaxx.nz Widget Clicked")}
+            title="Vaxx.nz Widget - Vaxx.nz Widget"
+          >
+            Vaxx.nz Widget
+          </a>{" "}
         </p>
         <p>
           <a


### PR DESCRIPTION
## Proposed Changes
1. Backlink to vaxx.nz widget

## Additional Info.
Link juice
