### PR TITLE
Force z-index on MonthSection

### DIFF
--- a/src/VaxComponents.js
+++ b/src/VaxComponents.js
@@ -86,6 +86,7 @@ export const CalendarSectionContainer = styled.section`
     border-bottom: 1px solid lightgray;
     position: sticky;
     top: 0px;
+    z-index: 2 !important;
 
     background-color: #fff;
   }


### PR DESCRIPTION
## Proposed Changes
1. Force zIndex for the month section to fix overlay issues on scroll

## Additional Info.
if unclear of what's breaking, while scrolling the month section falls behind the days & text.

## Screenshots (optional)
before: https://i.imgur.com/5Nrgx5e.png
after: https://i.imgur.com/oJpRI1s.png