### PR TITLE
Show CalendarError when there are no locations around you

### DIFF
--- a/src/calendar/Calendar.tsx
+++ b/src/calendar/Calendar.tsx
@@ -8,8 +8,8 @@ import { useTranslation } from "react-i18next";
 import i18next from "i18next";
 import {
   CalendarData,
-  CalendarDateLocations,
-  CalendarMonth,
+  CalendarDateLocations, CalendarLocation,
+  CalendarMonth
 } from "./CalendarData";
 import React from "react";
 import { useRadiusKm } from "../utils/useRadiusKm";
@@ -47,9 +47,9 @@ export const LoadingBookingCalendar: FunctionComponent = () => {
 };
 
 const getNumberOfAvailableLocations = (calendarData: [string, CalendarMonth][]): number => {
-  return calendarData.reduce((prev: number, it) =>
+  return calendarData.reduce((prev: number, it: [string, CalendarMonth]) =>
       prev +
-      Array.from(it[1].values()).reduce((prev, it) => prev + it.length, 0)
+      Array.from(it[1].values()).reduce((prev: number, it: CalendarLocation[]) => prev + it.length, 0)
     , 0);
 }
 

--- a/src/calendar/Calendar.tsx
+++ b/src/calendar/Calendar.tsx
@@ -1,5 +1,5 @@
 import CustomSpinner from "../utils/customSpinner";
-import { FunctionComponent } from "react";
+import { FunctionComponent, useMemo } from "react";
 import { sum } from "../utils/math";
 import { CalendarContainer } from "../VaxComponents";
 import { differenceInDays, parse } from "date-fns";
@@ -15,7 +15,6 @@ import React from "react";
 import { useRadiusKm } from "../utils/useRadiusKm";
 import { PageLink } from "../PageLink";
 import { styled } from "styletron-react";
-import { Calendar } from "baseui/datepicker";
 
 interface BookingCalendarProps {
   data: CalendarData;
@@ -59,7 +58,9 @@ export const BookingCalendar: FunctionComponent<BookingCalendarProps> = ({
   const { i18n } = useTranslation();
   const calendarData = Array.from(data);
   const { t } = useTranslation("common");
-  const bookingsAvailable = isBookingsAvailable(calendarData);
+  const bookingsAvailable = useMemo(() => isBookingsAvailable(calendarData),
+    [calendarData]
+  );
 
   console.log("Bookings Available: " + bookingsAvailable);
 

--- a/src/calendar/Calendar.tsx
+++ b/src/calendar/Calendar.tsx
@@ -15,6 +15,7 @@ import React from "react";
 import { useRadiusKm } from "../utils/useRadiusKm";
 import { PageLink } from "../PageLink";
 import { styled } from "styletron-react";
+import { CalendarError } from "./CalendarError";
 
 interface BookingCalendarProps {
   data: CalendarData;
@@ -62,27 +63,33 @@ export const BookingCalendar: FunctionComponent<BookingCalendarProps> = ({
     [calendarData]
   );
 
-  console.log("Bookings Available: " + bookingsAvailable);
+  if (bookingsAvailable) {
+    return (
+      <>
+        <div className="WalkSection2">
+          <h2>{t("core.availableBookingSlots")}</h2>
+          <p>{t("core.vaccApptToBook")}</p>
+        </div>
 
-  return (
-    <>
-      <div className="WalkSection2">
-        <h2>{t("core.availableBookingSlots")}</h2>
-        <p>{t("core.vaccApptToBook")}</p>
-      </div>
-
-      <CalendarContainer>
-        {calendarData.map(([monthStr, monthDates]) => (
-          <CalendarMonthContainer
-            key={monthStr}
-            monthStr={monthStr}
-            monthDates={monthDates}
-            language={i18n.language}
-          />
-        ))}
-      </CalendarContainer>
-    </>
-  );
+        <CalendarContainer>
+          {calendarData.map(([monthStr, monthDates]) => (
+            <CalendarMonthContainer
+              key={monthStr}
+              monthStr={monthStr}
+              monthDates={monthDates}
+              language={i18n.language}
+            />
+          ))}
+        </CalendarContainer>
+      </>
+    );
+  } else {
+    return (
+      <CalendarError
+        errorMessage={t("core.noVaccApptToBook")}
+      />
+    );
+  }
 };
 
 interface CalendarMonthContainerProps {

--- a/src/calendar/Calendar.tsx
+++ b/src/calendar/Calendar.tsx
@@ -15,6 +15,7 @@ import React from "react";
 import { useRadiusKm } from "../utils/useRadiusKm";
 import { PageLink } from "../PageLink";
 import { styled } from "styletron-react";
+import { Calendar } from "baseui/datepicker";
 
 interface BookingCalendarProps {
   data: CalendarData;
@@ -45,12 +46,23 @@ export const LoadingBookingCalendar: FunctionComponent = () => {
   );
 };
 
+const getNumberOfAvailableLocations = (calendarData: [string, CalendarMonth][]): number => {
+  return calendarData.reduce((prev: number, it) =>
+      prev +
+      Array.from(it[1].values()).reduce((prev, it) => prev + it.length, 0)
+    , 0);
+}
+
 export const BookingCalendar: FunctionComponent<BookingCalendarProps> = ({
   data,
 }) => {
   const { i18n } = useTranslation();
   const calendarData = Array.from(data);
   const { t } = useTranslation("common");
+  const bookingsAvailable = getNumberOfAvailableLocations(calendarData) !== 0;
+
+  console.log("Bookings Available: " + bookingsAvailable);
+
   return (
     <>
       <div className="WalkSection2">

--- a/src/calendar/Calendar.tsx
+++ b/src/calendar/Calendar.tsx
@@ -46,11 +46,11 @@ export const LoadingBookingCalendar: FunctionComponent = () => {
   );
 };
 
-const getNumberOfAvailableLocations = (calendarData: [string, CalendarMonth][]): number => {
+const isBookingsAvailable = (calendarData: [string, CalendarMonth][]): boolean => {
   return calendarData.reduce((prev: number, it: [string, CalendarMonth]) =>
       prev +
       Array.from(it[1].values()).reduce((prev: number, it: CalendarLocation[]) => prev + it.length, 0)
-    , 0);
+    , 0) !== 0;
 }
 
 export const BookingCalendar: FunctionComponent<BookingCalendarProps> = ({
@@ -59,7 +59,7 @@ export const BookingCalendar: FunctionComponent<BookingCalendarProps> = ({
   const { i18n } = useTranslation();
   const calendarData = Array.from(data);
   const { t } = useTranslation("common");
-  const bookingsAvailable = getNumberOfAvailableLocations(calendarData) !== 0;
+  const bookingsAvailable = isBookingsAvailable(calendarData);
 
   console.log("Bookings Available: " + bookingsAvailable);
 

--- a/src/translations/locales/common_en-NZ.json
+++ b/src/translations/locales/common_en-NZ.json
@@ -18,6 +18,7 @@
     "noResultsInRadius": "No vaccination sites found for this search query. Try a different search radius.",
     "availableBookingSlots": "Available Booking Slots",
     "vaccApptToBook": "Vaccination appointments available to book right now.",
+    "noVaccApptToBook": "Sorry, there are no vaccination sites in the selected area.",
     "mistake": "Did we make a mistake?"
   },
   "navigation": {


### PR DESCRIPTION
## Proposed Changes
1. If there are no bookings available, it displays an error message instead of a calendar full of "0 bookings available".
2. Added "noVacApptToBook" to en-NZ translation.

## Additional Info.
Closes #274

## Screenshots (optional)
![Screenshot 2021-11-01 002056](https://user-images.githubusercontent.com/50868057/139580572-a47fee51-392a-416a-883d-e3125e72a9ac.png)

