### PR TITLE
fix: capitalised Report Error button to keep styling consistent

### DIFF
--- a/src/calendar/CalendarError.tsx
+++ b/src/calendar/CalendarError.tsx
@@ -123,7 +123,7 @@ export function CalendarError(props: { errorMessage: string }) {
               href="https://github.com/CovidEngine/vaxxnz/issues"
               target="_blank"
             >
-              Report error
+              Report Error
             </Button>
           </Section>
         </TextContainer>


### PR DESCRIPTION
## Proposed Changes
1. Changed Report Error button text in CalendarError.tsx to uppercase

## Additional Info.
Fixes  #322 

## Screenshots (optional)
Before
![reportErrorOG](https://user-images.githubusercontent.com/70251176/139965626-97deba42-8be2-46cd-9479-4cfc448846fb.png)

After
![reportErrorCaps](https://user-images.githubusercontent.com/70251176/139965637-7d17cdab-1173-4ddd-b6aa-bf3445638137.png)
